### PR TITLE
14 skipping page following subchapter while within deference

### DIFF
--- a/pdf_classifier_core/src/classifiers/defer.rs
+++ b/pdf_classifier_core/src/classifiers/defer.rs
@@ -85,8 +85,9 @@ impl DeferralClassifier {
 
         while let Some(_) = self.base.poll() {}
 
+        self.base.should_defer = false;
         self.base.no_increment = self.original_no_increment;
-        self.base.current_page = self.current_page;
+        self.base.current_page = self.get_end_page();
         self.base.current_page.next();
 
         Ok(self.base)


### PR DESCRIPTION
Fixes the stated issue by ensuring the committed classifier's tracking on whether deference is enabled or not is `false` so it doesn't attempt to defer the same deferral - ensured the end page is actually the page that should be ended on. 